### PR TITLE
Fixed errors when parsing stream response

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -27,8 +27,6 @@ Parser.prototype.parse = function (chunk) {
     next = chunk[offset + 1];
     
     if(curr === '\r' && next === '\n') {
-      this.message = chunk.slice(offset, size);
-
       var piece = chunk.slice(start, offset);
       start = offset += 2;
       
@@ -45,4 +43,6 @@ Parser.prototype.parse = function (chunk) {
     }
     offset++;
   }
+
+  this.message = chunk.slice(start, size);
 };


### PR DESCRIPTION
As stream data could be spanned across several chunks, the current implementation fails to handle that as it assumes the chunk contains a valid JSON-parseable string. In my implementation chunks get concatenated until the delimiter (\r\n) is found. If there are leftovers they get concatenated with the next chunk. Testing with the statuses/sample stream resulted in no parsing errors.
