### PR TITLE
Handle disconnect messages

### DIFF
--- a/lib/oarequest.js
+++ b/lib/oarequest.js
@@ -96,6 +96,7 @@ OARequest.prototype.end = function (persist, callback) {
         if      (msg['delete'])     { self.emit('delete', msg); }
         else if (msg['limit'])      { self.emit('limit', msg);  }     
         else if (msg['scrub_geo'])  { self.emit('scrub_geo', msg); }
+        else if (msg['disconnect']) { self.emit('error', msg); }
         else                        { self.emit('tweet', msg); }
       })
       .on('error', function (err)   { self.emit('error', err); });


### PR DESCRIPTION
I was trying to stream status/filter and was getting busted "tweets" coming through:

```
{ disconnect: 
   { code: 7,
     stream_name: 'dfurnes-statuses936291',
     reason: 'admin logout' } }
```

Turned out I had another client connected on that same account so it was rejecting the second one though in a sort of undocumented manner. It seems like we should pass those back as error events... though it might make sense to just emit("stop") if we get those to shut ourselves down... I really don't know what the best solution would be so I'm just submitting this to start the conversation.
