### PR TITLE
fix stream reconnection bug

### DIFF
--- a/lib/oarequest.js
+++ b/lib/oarequest.js
@@ -127,9 +127,8 @@ OARequest.prototype.keepAlive = function () {
       self.abortedBy = 'twitter'
       
       if (self.connectInterval === undefined) {
-        self.request = self.keepAlive()
         self.connectInterval = 0
-        return
+        return self.keepAlive()
       }
       //rate limited - back off for a minute (danger of getting blocked by twitter)
       if (res && res.statusCode === 420) 
@@ -143,7 +142,7 @@ OARequest.prototype.keepAlive = function () {
       self.emit('reconnect', self.request, res, self.connectInterval)
       
       setTimeout(function () {
-        self.request = self.keepAlive()
+        self.keepAlive()
       }, self.connectInterval)
     })
     .on('error', function (err) {


### PR DESCRIPTION
When the client tries to reconnect after a disconnect, the `OARequest` instance is assigned to the request ([here](https://github.com/ttezel/twit/blob/master/lib/oarequest.js#L130) and [here](https://github.com/ttezel/twit/blob/master/lib/oarequest.js#L146)).

This cause the `stop()` method to fail after a reconnection because `this.request` ([L85](https://github.com/ttezel/twit/blob/master/lib/oarequest.js#L85)) now points to the `OARequest` instance and has no method `abort()`.

You are already assigning `this.request` [here](https://github.com/ttezel/twit/blob/master/lib/oarequest.js#L100) and i think this is enought. Calling `self.keepAlive()` is sufficient in the reconnection logic.

I didn't create a test for this, can try to forge one if needed.
