### PR TITLE
Exclamation Twitter Encoding issue

### DIFF
--- a/lib/oarequest.js
+++ b/lib/oarequest.js
@@ -23,7 +23,7 @@ function OARequest (oauth, method, path, params) {
   this.method = method
 
   if (method === 'GET') {
-    this.path = path + (params ? '?' + querystring.stringify(params) : '')
+    this.path = path + (params ? '?' + querystring.stringify(params).replace(/\!/g,'%21') : '')
     this.params = null
   } else if (method === 'POST') {
     this.path = path


### PR DESCRIPTION
Twitter will give a NOAUTH  when it sees an unencoded Exclamation mark.

Here is a link from twitter dev discussion

https://dev.twitter.com/discussions/12378

Btw, nice little API we use it at Manta.com
