### PR TITLE
Add stall protection

### DIFF
--- a/lib/oarequest.js
+++ b/lib/oarequest.js
@@ -110,7 +110,10 @@ OARequest.prototype.keepAlive = function () {
 
       //pass all response data to parser to get parsed
       res.on('data', function (chunk) {
-        self.parser.parse(chunk) 
+        //reset stall timer
+        self.resetStallTimer()
+
+        self.parser.parse(chunk)
       })
     })
     //tcp errors:
@@ -120,6 +123,8 @@ OARequest.prototype.keepAlive = function () {
     //
     //back off linearly @ 250ms til 16s, then double til 320s
     .on('close', function () {
+      self.stopStallTimer()
+
       //self.abortedBy gets set to `twit-client` if .stop() is called
       //in that case, do not schedule a reconnect; return immediately
       if (self.abortedBy === 'twit-client')
@@ -150,7 +155,7 @@ OARequest.prototype.keepAlive = function () {
       }, self.connectInterval)
     })
     .on('error', function (err) {
-      //don't need to do anything here; this gets called when the request is abort()'ed' 
+      self.stopStallTimer()
     })
     .end()
       
@@ -235,6 +240,30 @@ OARequest.prototype.makeRequest = function (cb) {
     , this.params
     , cb
   )
+}
+
+/**
+ * Stops and restarts the stall timer
+ *
+ */
+OARequest.prototype.resetStallTimer = function () {
+  var self = this
+
+  this.stopStallTimer()
+
+  //start a 90s timer to trigger a reconnect
+  this.stallTimer = setTimeout(function () {
+    self.request.abort()
+  }, 90000)
+}
+
+/**
+ * Stops stall timer
+ *
+ */
+OARequest.prototype.stopStallTimer = function () {
+  if (this.stallTimer)
+    clearTimeout(this.stallTimer)
 }
 
 module.exports = OARequest


### PR DESCRIPTION
Adds protection against stalls as documented on https://dev.twitter.com/docs/streaming-apis/connecting#Stalls

Resets a 90s timer when data is received and triggers a reconnect when the timer has completed.
