### PR TITLE
Fix unintended error catching in parser.js

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -34,11 +34,11 @@ Parser.prototype.parse = function (chunk) {
       
       try {
         var msg = JSON.parse(piece)
-
-        this.emit('element', msg)
       } catch (err) {
         this.emit('error', new Error('Error parsing twitter reply: `'+piece+'`, error message `'+err+'`'));
       } finally {
+        if (msg)
+          this.emit('element', msg)
         continue;
       }
     }


### PR DESCRIPTION
Hi :)

This patch fixes an unintended behavior in the parser.

The JSON.parse() call is wrapped in a try catch block to catch parser errors, which is fine.

However, the emit('element') call is also wrapped inside this, so that any error thrown in the event chain this starts will be caught here, too.
