### PR TITLE
adding clearTimeout on stop, thus forcing avoiding the call of reconnect

### DIFF
--- a/lib/oarequest.js
+++ b/lib/oarequest.js
@@ -21,6 +21,7 @@ function OARequest (oauth, method, path, params) {
   }
   this.oauth = oauth
   this.method = method
+  this.timerReconnect = ''
 
   if (method === 'GET') {
     this.path = path + (params ? '?' + querystring.stringify(params) : '')
@@ -107,6 +108,7 @@ OARequest.prototype.start = function () {
  */
 OARequest.prototype.stop = function () {
   this.abortedBy = 'twit-client'
+  clearTimeout(this.timerReconnect)
   this.request.abort()
   return this
 }
@@ -172,7 +174,7 @@ OARequest.prototype.keepAlive = function () {
 
       self.emit('reconnect', self.request, res, self.connectInterval)
 
-      setTimeout(function () {
+      self.timerReconnect = setTimeout(function () {
         self.keepAlive()
       }, self.connectInterval)
     })
@@ -341,4 +343,3 @@ OARequest.prototype.stopStallTimer = function () {
 }
 
 module.exports = OARequest
-


### PR DESCRIPTION
Hi ! Using the stop call in https://github.com/ttezel/twit#streamstop I've noticed that the reconnect function was keep called. 
I just added a variable that save the timeout call and clear it when stop is called. I've tried to break on : 
https://github.com/ttezel/twit/blob/master/lib/oarequest.js#L152

But sometimes it pass this condition. 

I perfectly admit this is a hack, but anyway, it might help someone.