### PR TITLE
Passing along HTTP response on error

### DIFF
--- a/lib/oarequest.js
+++ b/lib/oarequest.js
@@ -209,7 +209,7 @@ OARequest.prototype.handleDisconnect = function (msg) {
 OARequest.prototype.end = function (callback) {
   function handler (err, raw, response) {
     if (err instanceof Error) {
-      return callback(err)
+      return callback(err, undefined, response)
     }
 
     // handle http errors
@@ -243,13 +243,13 @@ OARequest.prototype.end = function (callback) {
       // keep consistent with the rest of the error handling by passing the raw response data here
       error.twitterReply = err.data
 
-      return callback(error)
+      return callback(error, undefined, response)
     }
 
     // handle non-http errors
     if (err) {
       err.twitterReply = raw
-      return callback(err)
+      return callback(err, undefined, response)
     }
 
     // parse response
@@ -265,13 +265,13 @@ OARequest.prototype.end = function (callback) {
 
     // handle parsing errors
     if (parseError) {
-      return callback(parseError)
+      return callback(parseError, undefined, response)
     } else if (!parsed) {
       // null, false or empty reply
       var badReplyError = new Error('twitter sent bad reply: `'+parsed+'`.')
       badReplyError.twitterReply = raw
 
-      return callback(badReplyError)
+      return callback(badReplyError, undefined, response)
     }
 
     // success case

--- a/tests/rest.js
+++ b/tests/rest.js
@@ -401,7 +401,7 @@ describe('REST API', function () {
 
   describe('error handling', function () {
     describe('handling errors from the twitter api', function () {
-      it('should callback with an Error object with all the info', function (done) {
+      it('should callback with an Error object with all the info and a response object', function (done) {
         var twit = new Twit({
           consumer_key: 'a',
           consumer_secret: 'b',
@@ -416,7 +416,7 @@ describe('REST API', function () {
           assert(err.twitterReply)
           assert(err.allErrors)
           assert(!reply)
-          assert(!res)
+          checkResponse(res);
           done()
         })
       })


### PR DESCRIPTION
Fixes #75.  Using the REST API, the response was getting swallowed
when any error occurred.  Response headers are useful in some
cases, such as rate-limit errors, so passing the response through
to the user's callback is valuable.  One test was updated to
account for this new behavior.
