### PR TITLE
Return request object in get/post

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -81,7 +81,10 @@ Twitter.prototype = {
     // convert any arrays in `paramsClone` to comma-seperated strings
     var finalParams = this.normalizeParams(paramsClone)
 
-    return new OARequest(this.auth, method, finalPath + '.json', finalParams).end(callback)
+    var req = new OARequest(this.auth, method, finalPath + '.json', finalParams)
+    req.end(callback)
+    
+    return req
   },
   stream: function (path, params) {
     var ROOT = STREAM_ENDPOINT_MAP[path] || PUB_STREAM

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -40,10 +40,10 @@ var Twitter = function (config) {
 
 Twitter.prototype = {
   get: function (path, params, callback) {
-    this.request('GET', REST_ROOT + path, params, callback)
+    return this.request('GET', REST_ROOT + path, params, callback)
   },
   post: function (path, params, callback) {
-    this.request('POST', REST_ROOT + path, params, callback)
+    return this.request('POST', REST_ROOT + path, params, callback)
   },
   request: function (method, path, params, callback) {
     if (typeof params === 'function') {


### PR DESCRIPTION
The OARequest object can emit errors (which will crash the process if left uncaught), but the request is never returned.