### PR TITLE
emit authorization error on streaming request

### DIFF
--- a/lib/oarequest.js
+++ b/lib/oarequest.js
@@ -147,6 +147,14 @@ OARequest.prototype.keepAlive = function () {
     .on('close', function () {
       self.stopStallTimer()
 
+      if (res && res.statusCode === 401) {
+        var err = new Error('HTTP error: ' + res.statusCode)
+        err.code = res.statusCode
+        self.emit('error', err)
+        self.abortedBy = 'twit-client'
+        return
+      }
+
       //self.abortedBy gets set to `twit-client` if twit.stop() is called.
       //Since we stopped it explicity, don't try to reconnect
       if (self.abortedBy === 'twit-client')

--- a/tests/oarequest.test.js
+++ b/tests/oarequest.test.js
@@ -1,0 +1,52 @@
+var OARequest = require('../lib/oarequest')
+var EventEmitter = require('events').EventEmitter
+var assert = require('assert')
+
+describe('OARequest', function () {
+
+  describe('streaming', function () {
+    it('aborts on 401 authorization error', function (done) {
+
+      var origMakeRequest = OARequest.prototype.makeRequest
+
+      OARequest.prototype.makeRequest = function (cb) {
+        var req = new EventEmitter()
+        req.end = function () {}
+        var self = this
+      
+
+        // schedule events for next tick, once keepAlive
+        // can add handlers
+        process.nextTick(function () {
+
+          req.emit('response', {
+            statusCode: 401,
+            setEncoding: function (){},
+            on: function () {}
+          })
+
+          req.emit('close')
+
+          assert(self.abortedBy === 'twit-client', 'the request should be aborted by the client')
+
+        })
+
+        return req
+      }
+
+      //
+      var req = new OARequest({}, 'GET', '')
+
+
+      req.on('error', function (err) {
+        assert(err.code === 401, 'error should contain the http status code')
+        done()
+      })
+
+      req.keepAlive()
+
+
+    })
+  })
+  
+})


### PR DESCRIPTION
Previously, there was no way of knowing if you Twitter credentials were working properly on streaming methods. This pull request checks for 401 auth errors and emits an `error` event on the OARequest object.