### PR TITLE
fix friends msg when stringify_friend_ids=true

### DIFF
--- a/lib/oarequest.js
+++ b/lib/oarequest.js
@@ -62,16 +62,16 @@ OARequest.prototype.persist = function () {
   this.parser.on('element', function (msg) {
     // first msg; successful connection => reset reconnect interval
     self.connectInterval = 0
-    if      (msg.delete)          { self.emit('delete', msg) }
-    else if (msg.disconnect)      { self.handleDisconnect(msg) }
-    else if (msg.limit)           { self.emit('limit', msg) }
-    else if (msg.scrub_geo)       { self.emit('scrub_geo', msg) }
-    else if (msg.warning)         { self.emit('warning', msg) }
-    else if (msg.status_withheld) { self.emit('status_withheld', msg) }
-    else if (msg.user_withheld)   { self.emit('user_withheld', msg) }
-    else if (msg.friends)         { self.emit('friends', msg) }
-    else if (msg.direct_message)  { self.emit('direct_message', msg) }
-    else if (msg.event)           {
+    if      (msg.delete)                      { self.emit('delete', msg) }
+    else if (msg.disconnect)                  { self.handleDisconnect(msg) }
+    else if (msg.limit)                       { self.emit('limit', msg) }
+    else if (msg.scrub_geo)                   { self.emit('scrub_geo', msg) }
+    else if (msg.warning)                     { self.emit('warning', msg) }
+    else if (msg.status_withheld)             { self.emit('status_withheld', msg) }
+    else if (msg.user_withheld)               { self.emit('user_withheld', msg) }
+    else if (msg.friends || msg.friends_str)  { self.emit('friends', msg) }
+    else if (msg.direct_message)              { self.emit('direct_message', msg) }
+    else if (msg.event)                       {
       self.emit('user_event', msg)
       // reference: https://dev.twitter.com/docs/streaming-apis/messages#User_stream_messages
       var ev = msg.event


### PR DESCRIPTION
Right now, the friends message gets erroneously routed as a tweet if you pass `stringify_friends_ids=true` to a user stream. This fixes that. 