### PR TITLE
Added 'Retweet' 'Searchfollow' and 'favorite' examples

### DIFF
--- a/examples/bot.js
+++ b/examples/bot.js
@@ -27,15 +27,9 @@ Bot.prototype.searchFollow = function (params, callback) {
     if(err) return callback(err);
  
     var tweets = reply.statuses;
-	var randTweet = randIndex(tweets);
-	if(randTweet)
-	{
-		var target = randTweet.user.id_str;
+    var target = randIndex(tweets).user.id_str;
  
-		self.twit.post('friendships/create', { id: target }, callback);
-	}
-	else
-		return callback(new Error('Could not find tweet.'));
+    self.twit.post('friendships/create', { id: target }, callback);
   });
 };
 

--- a/examples/bot.js
+++ b/examples/bot.js
@@ -27,9 +27,13 @@ Bot.prototype.searchFollow = function (params, callback) {
     if(err) return callback(err);
  
     var tweets = reply.statuses;
-    var target = randIndex(tweets).user.id_str;
+	var rTweet = randIndex(tweets)
+	if(typeof rTweet != 'undefined')
+	{
+		var target = rTweet.user.id_str;
  
-    self.twit.post('friendships/create', { id: target }, callback);
+		self.twit.post('friendships/create', { id: target }, callback);
+	}
   });
 };
 
@@ -44,8 +48,8 @@ Bot.prototype.retweet = function (params, callback) {
  
     var tweets = reply.statuses;
     var randomTweet = randIndex(tweets);
- 
-    self.twit.post('statuses/retweet/:id', { id: randomTweet.id_str }, callback);
+	if(typeof randomTweet != 'undefined')
+		self.twit.post('statuses/retweet/:id', { id: randomTweet.id_str }, callback);
   });
 };
  
@@ -60,8 +64,8 @@ Bot.prototype.favorite = function (params, callback) {
  
     var tweets = reply.statuses;
     var randomTweet = randIndex(tweets);
- 
-    self.twit.post('favorites/create', { id: randomTweet.id_str }, callback);
+	if(typeof randomTweet != 'undefined')
+		self.twit.post('favorites/create', { id: randomTweet.id_str }, callback);
   });
 };
 

--- a/examples/bot.js
+++ b/examples/bot.js
@@ -20,6 +20,57 @@ Bot.prototype.tweet = function (status, callback) {
   this.twit.post('statuses/update', { status: status }, callback);
 };
 
+Bot.prototype.searchFollow = function (params, callback) {
+  var self = this;
+ 
+  self.twit.get('search/tweets', params, function (err, reply) {
+    if(err) return callback(err);
+ 
+    var tweets = reply.statuses;
+	var randTweet = randIndex(tweets);
+	if(randTweet)
+	{
+		var target = randTweet.user.id_str;
+ 
+		self.twit.post('friendships/create', { id: target }, callback);
+	}
+	else
+		return callback(new Error('Could not find tweet.'));
+  });
+};
+
+//
+// retweet
+//
+Bot.prototype.retweet = function (params, callback) {
+  var self = this;
+ 
+  self.twit.get('search/tweets', params, function (err, reply) {
+    if(err) return callback(err);
+ 
+    var tweets = reply.statuses;
+    var randomTweet = randIndex(tweets);
+ 
+    self.twit.post('statuses/retweet/:id', { id: randomTweet.id_str }, callback);
+  });
+};
+ 
+//
+// favorite a tweet
+//
+Bot.prototype.favorite = function (params, callback) {
+  var self = this;
+ 
+  self.twit.get('search/tweets', params, function (err, reply) {
+    if(err) return callback(err);
+ 
+    var tweets = reply.statuses;
+    var randomTweet = randIndex(tweets);
+ 
+    self.twit.post('favorites/create', { id: randomTweet.id_str }, callback);
+  });
+};
+
 //
 //  choose a random friend of one of your followers, and follow that user
 //


### PR DESCRIPTION
Added 'Retweet' 'Searchfollow' and 'Favorite' examples to bot.js.  Original ideas shared by:
http://www.apcoder.com/2013/10/03/twitter-bot-20-minutes-node-js/

I cleaned up the code and added error handling, so it is much more stable.  I think these make excellent example functions for 'twit', and I think that they make useful samples in addition to the great samples already provided.