### PR TITLE
Added mediaUpload method

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ T.post('statuses/update', { status: 'hello world!' }, function(err, data, respon
 //
 // upload media
 //
-T.mediaUpload({ media : fs.readFileSync('/path/toFile', {encoding : 'base64'})}, function(err, data, response) {
+var contents = fs.readFileSync('/path/toFile', {encoding : 'base64'});
+T.mediaUpload({ media : contents }, function(err, data, response) {
 	console.log(data);
 });
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ T.post('statuses/update', { status: 'hello world!' }, function(err, data, respon
 })
 
 //
+// upload media
+//
+T.mediaUpload({ media : fs.readFileSync('/path/toFile', {encoding : 'base64'})}, function(err, data, response) {
+	console.log(data);
+});
+
+//
 //  search twitter for all tweets containing the word 'banana' since Nov. 11, 2011
 //
 T.get('search/tweets', { q: 'banana since:2011-11-11', count: 100 }, function(err, data, response) {
@@ -127,6 +134,10 @@ The endpoint to hit. When specifying `path` values, omit the **'.json'** at the 
 ##`T.post(path, [params], callback)`
 
 POST any of the REST API endpoints. Same usage as `T.get()`.
+
+##`mediaUpload(params, callback)`
+
+POST base64 data to the MEDIA UPLOAD endpoint.
 
 ##`T.getAuth()`
 Get the client's authentication tokens.

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -11,6 +11,7 @@ var REST_ROOT     = 'https://api.twitter.com/1.1/'
   , SITE_STREAM   = 'https://sitestream.twitter.com/1.1/'
   , OA_REQ        = 'https://api.twitter.com/oauth/request_token'
   , OA_ACCESS     = 'https://api.twitter.com/oauth/access_token'
+  , MEDIA_UPLOAD  = 'https://upload.twitter.com/1.1/'
 
 //
 //  Twitter
@@ -39,6 +40,9 @@ Twitter.prototype = {
   },
   post: function (path, params, callback) {
     return this.request('POST', REST_ROOT + path, params, callback)
+  },
+  mediaUpload : function(params, callback) {
+    return this.request('POST', MEDIA_UPLOAD + 'media/upload', params, callback)
   },
   request: function (method, path, params, callback) {
     // if no `params` is specified but a callback is, use default params

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -24,7 +24,7 @@ var Twitter = function (config) {
     , consumer_secret     : config.consumer_secret
     , access_token        : config.access_token
     , access_token_secret : config.access_token_secret
-  }
+  };
 
   this.config = config;
   this.config.oauth_request_url = OA_REQ;
@@ -41,8 +41,8 @@ Twitter.prototype = {
   post: function (path, params, callback) {
     return this.request('POST', REST_ROOT + path, params, callback)
   },
-  mediaUpload : function(params, callback) {
-    return this.request('POST', MEDIA_UPLOAD + 'media/upload', params, callback)
+  upload : function(path, params, callback) {
+    return this.request('POST', MEDIA_UPLOAD + path, params, callback)
   },
   request: function (method, path, params, callback) {
     // if no `params` is specified but a callback is, use default params

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "main": "./lib/twitter",
   "repository": {
     "type": "git",
-    "url": "http://github.com/ttezel/twit.git"
+    "url": "https://github.com/VoxFeed/twit.git"
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha tests/* -t 70000 -R spec --bail"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "main": "./lib/twitter",
   "repository": {
     "type": "git",
-    "url": "https://github.com/VoxFeed/twit.git"
+    "url": "git@github.com:VoxFeed/twit.git"
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha tests/* -t 70000 -R spec --bail"


### PR DESCRIPTION
Modifying the current post method does not makes much sense since it's supposed to send the request to the REST API.  A media upload method should send request to upload.twitter.com.

For now T.mediaUpload(params, callback) can do the trick.

The recent API changes by Twitter might call for a version change in which we could have namespaces. Something like:

T.rest.post
T.rest.get
T.media.post
etc.

Then calling T.media.post('media/upload', params, callback)