### PR TITLE
added friends_str event

### DIFF
--- a/lib/streaming-api-connection.js
+++ b/lib/streaming-api-connection.js
@@ -270,6 +270,7 @@ StreamingAPIConnection.prototype._setupParser = function () {
     else if (msg.status_withheld) { self.emit('status_withheld', msg) }
     else if (msg.user_withheld)   { self.emit('user_withheld', msg) }
     else if (msg.friends)         { self.emit('friends', msg) }
+    else if (msg.friends_str)     { self.emit('friends_str', msg) }
     else if (msg.direct_message)  { self.emit('direct_message', msg) }
     else if (msg.event)           {
       self.emit('user_event', msg)


### PR DESCRIPTION
previously the friends preamble would emit a 'tweet' event if the stream was opened with stringify_friend_ids=true (via the final 'else'). gave it its own event for consistency with the rest of the api (twitter serves {friends_str:[]} rather than just friends) but it may make sense to fold it into the friends event instead.