### PR TITLE
Updating broken/old links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,10 +422,10 @@ Note: there is no need to call `.start()` to begin streaming. `Twit.stream` call
 
 Anything in the Twitter API:
 
-* REST API Endpoints:       https://dev.twitter.com/docs/api
-* Public stream endpoints:  https://dev.twitter.com/docs/streaming-api/methods
-* User stream endpoints:    https://dev.twitter.com/docs/streaming-api/user-streams
-* Site stream endpoints:    https://dev.twitter.com/docs/streaming-api/site-streams
+* REST API Endpoints:       https://dev.twitter.com/overview/api
+* Public stream endpoints:  https://dev.twitter.com/streaming/public
+* User stream endpoints:    https://dev.twitter.com/streaming/userstreams
+* Site stream endpoints:    https://dev.twitter.com/streaming/sitestreams
 
 -------
 


### PR DESCRIPTION
Just some updates to the links in the docs. There were several links that were broken and a couple that were pointing to old URL's that have since changed.