### PR TITLE
Fix reconnect not scheduled in certain cases

### DIFF
--- a/lib/streaming-api-connection.js
+++ b/lib/streaming-api-connection.js
@@ -180,6 +180,7 @@ StreamingAPIConnection.prototype._onClose = function () {
  *
  */
 StreamingAPIConnection.prototype.start = function () {
+  this._abortedBy = null;
   this._resetRetryParams();
   this._startPersistentConnection();
   return this;

--- a/lib/streaming-api-connection.js
+++ b/lib/streaming-api-connection.js
@@ -146,9 +146,12 @@ StreamingAPIConnection.prototype._startPersistentConnection = function () {
       self.emit('connected', self.response);
     }
   });
-  self.request.on('close', self._onClose.bind(self));
-  self.request.on('error', function (err) { self._scheduleReconnect.bind(self) });
-  return self;
+  this.request.on('close', self._onClose.bind(self));
+  this.request.on('error', function (err) {
+    self.emit('error', err);
+    self._scheduleReconnect();
+  });
+  return this;
 }
 
 /**


### PR DESCRIPTION
I run into problems where Twit won't reschedule its streaming connection, and so far I think I identified two places where might be a problem.

1. `_abortedBy` is set when calling `.stop()`, but this flag is not reset when calling subsequent `.start()`. This means if I restart a connection explicitly, future `_onClose` handler will see the `_abortedBy` flag and **not** schedule a reconnect.
2. Error handler on request doesn't seem to actually call `_scheduleReconnect` nor do anything about the error. So that's changed.

There might be more to this problem, but I'm having a hard time tracking them down.