### PR TITLE
regenerate oauth timestamp when stream reconnect

### DIFF
--- a/lib/streaming-api-connection.js
+++ b/lib/streaming-api-connection.js
@@ -12,6 +12,7 @@ var STATUS_CODES_TO_ABORT_ON = require('./settings').STATUS_CODES_TO_ABORT_ON
 var StreamingAPIConnection = function (reqOpts, twitOptions) {
   this.reqOpts = reqOpts
   this.twitOptions = twitOptions
+  this._twitter_time_minus_local_time_ms = 0
   EventEmitter.call(this)
 }
 
@@ -64,9 +65,21 @@ StreamingAPIConnection.prototype._startPersistentConnection = function () {
   self._resetConnection();
   self._setupParser();
   self._resetStallAbortTimeout();
+  if (self.reqOpts.oauth && typeof self.reqOpts.oauth === 'object') {
+    var oauth_ts = Date.now() + self._twitter_time_minus_local_time_ms;
+    self.reqOpts.oauth.timestamp = Math.floor(oauth_ts/1000).toString();
+  }
   self.request = request.post(this.reqOpts);
   self.emit('connect', self.request);
   self.request.on('response', function (response) {
+
+    if (response && response.headers && response.headers.date &&
+        new Date(response.headers.date).toString() !== 'Invalid Date'
+    ) {
+      var twitterTimeMs = new Date(response.headers.date).getTime()
+      self._twitter_time_minus_local_time_ms = twitterTimeMs - Date.now();
+    }
+
     // reset our reconnection attempt flag so next attempt goes through with 0 delay
     // if we get a transport-level error
     self._usedFirstReconnect = false;


### PR DESCRIPTION
This fix the stream reconnection issue with the 401 error described : #253 and here #245 

The 401 error is returned by twitter because when the stream reconnect it take the timestamp for the oauth process of the last connection attempt (wich can be very old). The timestamp must be near from the current time in order  that the signature of the request can be considered as valid by twitter.