### PR TITLE
Alt text (POST /media/metadata/create) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,21 @@ var b64content = fs.readFileSync('/path/to/img', { encoding: 'base64' })
 
 // first we must post the media to Twitter
 T.post('media/upload', { media_data: b64content }, function (err, data, response) {
-
-  // now we can reference the media and post a tweet (media will attach to the tweet)
+  // now we can assign alt text to the media, for use by screen readers and
+  // other text-based presentations and interpreters
   var mediaIdStr = data.media_id_string
-  var params = { status: 'loving life #nofilter', media_ids: [mediaIdStr] }
+  var altText = "Small flowers in a planter on a sunny balcony, blossoming."
+  var meta_params = { media_id: mediaIdStr, alt_text: { text: altText } }
 
-  T.post('statuses/update', params, function (err, data, response) {
-    console.log(data)
+  T.post('media/metadata/create', meta_params, function (err, data, response) {
+    if (!err) {
+      // now we can reference the media and post a tweet (media will attach to the tweet)
+      var params = { status: 'loving life #nofilter', media_ids: [mediaIdStr] }
+
+      T.post('statuses/update', params, function (err, data, response) {
+        console.log(data)
+      })
+    }
   })
 })
 

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -29,6 +29,10 @@ var FORMDATA_PATHS = [
   'account/update_profile_background_image',
 ];
 
+var JSONPAYLOAD_PATHS = [
+  'media/metadata/create'
+]
+
 //
 //  Twitter
 //
@@ -215,9 +219,9 @@ Twitter.prototype._buildReqOpts = function (method, path, params, isStreaming, c
   } else {
     // This is a REST API request.
 
-    if (path === 'media/upload') {
-      // For media/upload, use a different entpoint and formencode.
-      reqOpts.url = endpoints.MEDIA_UPLOAD + 'media/upload.json';
+    if (path.indexOf('media/') !== -1) {
+      // For media/upload, use a different endpoint.
+      reqOpts.url = endpoints.MEDIA_UPLOAD + path + '.json';
     } else {
       reqOpts.url = endpoints.REST_ROOT + path + '.json';
     }
@@ -227,6 +231,12 @@ Twitter.prototype._buildReqOpts = function (method, path, params, isStreaming, c
       reqOpts.form = finalParams;
        // set finalParams to empty object so we don't append a query string
       // of the params
+      finalParams = {};
+    } else if (JSONPAYLOAD_PATHS.indexOf(path) !== -1) {
+      reqOpts.headers['Content-type'] = 'application/json';
+      reqOpts.json = true;
+      reqOpts.body = finalParams;
+      // as above, to avoid appending query string for body params
       finalParams = {};
     } else {
       reqOpts.headers['Content-type'] = 'application/json';

--- a/tests/rest.js
+++ b/tests/rest.js
@@ -534,6 +534,26 @@ describe('REST API', function () {
         done()
       })
     })
+
+    it('POST media/upload with JPG, then POST media/metadata/create with alt text', function (done) {
+      var b64content = fs.readFileSync(__dirname + '/img/bigbird.jpg', { encoding: 'base64' })
+
+      twit.post('media/upload', { media_data: b64content }, function (err, data, response) {
+        assert(!err, err)
+        exports.checkMediaUpload(data)
+        assert.equal(data.image.image_type, 'image/jpeg')
+
+        var mediaIdStr = data.media_id_string
+        assert(mediaIdStr)
+        var altText = 'a very small Big Bird'
+        var params = { media_id: mediaIdStr, alt_text: { text: altText } }
+        twit.post('media/metadata/create', params, function (err, data, response) {
+          assert(!err, err)
+          // data is empty on media/metadata/create success; nothing more to assert
+          done();
+        })
+      })
+    })
   })
 
   it('POST account/update_profile_image', function (done) {


### PR DESCRIPTION
  - Apply `MEDIA_UPLOAD` domain to all requests with `media/*` paths
  - Add `JSONPAYLOAD_PATHS` holding application/json paths that cannot use query string
  - Set `reqOpts.json` & assign `finalParams` to `reqOpts.body` for JSON payload paths
  - Add test: POST JPG, then POST alt_text to resulting media_id