### PR TITLE
Upgrade vulnerable dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 #twit
+[![Known Vulnerabilities](https://snyk.io/test/github/ttezel/twit/badge.svg)](https://snyk.io/test/github/ttezel/twit)
 
 Twitter API Client for node
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "bluebird": "^3.1.5",
     "mime": "^1.3.4",
-    "request": "2.58.0"
+    "request": "^2.68.0"
   },
   "devDependencies": {
     "async": "0.2.9",
@@ -22,6 +22,7 @@
     "commander": "2.6.0",
     "mocha": "2.1.0",
     "rewire": "2.3.4",
+    "snyk": "^1.13.3",
     "sinon": "1.15.4"
   },
   "engines": {
@@ -34,6 +35,6 @@
     "url": "http://github.com/ttezel/twit.git"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha tests/* -t 70000 -R spec --bail --globals domain,_events,_maxListeners"
+    "test": "snyk test && ./node_modules/.bin/mocha tests/* -t 70000 -R spec --bail --globals domain,_events,_maxListeners"
   }
 }


### PR DESCRIPTION
`twit` currently uses a vulnerable version of `request`, which also pulls in a vulnerable version of `hawk`.
You can see details here (note this points to the latest commit hash at the time of this PR): https://snyk.io/test/github/ttezel/twit/3fc6d7c14fd4115f212b010bb531352d67869b35

This PR upgrades `request` to the minimal version that isn't vulnerable. 
This includes no major upgrades, so should have no disruption.

I also added `snyk test` to the test process, to help the project stay vulnerability free (will fail the test if new vulns are introduced). I recommend you also monitor the project by running [`snyk wizard`](https://snyk.io/docs/using-snyk/#wizard), doing so will alert you when a new vulnerability that affects your dependencies is disclosed.

Lastly, to show the world you're doing a good job on security (and that they should care), I took the liberty of adding a badge stating you're free of known vulnerabilities. If you're gonna be awesome, no reason to hide it!
Note that the badge works off the latest master branch, so it'll show red until you actually merge this in.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)
