### PR TITLE
Add 'mute' and 'unmute' streaming events

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,8 @@ In addition, the following user stream events are provided for you to listen on:
 * `unfavorite`
 * `follow`
 * `unfollow`
+* `mute`
+* `unmute`
 * `user_update`
 * `list_created`
 * `list_destroyed`

--- a/lib/streaming-api-connection.js
+++ b/lib/streaming-api-connection.js
@@ -297,6 +297,8 @@ StreamingAPIConnection.prototype._setupParser = function () {
       else if (ev === 'unfavorite')             { self.emit('unfavorite', msg) }
       else if (ev === 'follow')                 { self.emit('follow', msg) }
       else if (ev === 'unfollow')               { self.emit('unfollow', msg) }
+      else if (ev === 'mute')                   { self.emit('mute', msg) }
+      else if (ev === 'unmute')                 { self.emit('unmute', msg) }
       else if (ev === 'user_update')            { self.emit('user_update', msg) }
       else if (ev === 'list_created')           { self.emit('list_created', msg) }
       else if (ev === 'list_destroyed')         { self.emit('list_destroyed', msg) }


### PR DESCRIPTION
Thank you for great library.  It's very helpful because I'm creating Twitter client.  I noticed that `mute` and `unmute` events are missing in streaming APIs.

https://twittercommunity.com/t/adding-new-features-to-streaming-api/15214

So I added them in this PR.