### PR TITLE
check for full url before looking up endpoint, short circuit if fully qualified

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -207,6 +207,10 @@ Twitter.prototype._buildReqOpts = function (method, path, params, isStreaming, c
     return
   }
 
+  if (path.match(/^https?:\/\//i)) {
+    // This is a full url request
+    reqOpts.url = path
+  } else
   if (isStreaming) {
     // This is a Streaming API request.
 


### PR DESCRIPTION
Twitter has several apis that do not adhere to the lookup schema provided by twit.  For instance the ads REST api (https://dev.twitter.com/ads).  

This pull request adds a short-circuit check before performing endpoint lookup.  It checks for "http" or "https" requests.  If found it sets the requestUrl to that.