### PR TITLE
Make Promise API reject on Twitter API errors

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -78,8 +78,9 @@ Twitter.prototype.request = function (method, path, params, callback) {
     var _returnErrorToUser = function (err) {
       if (callback && typeof callback === 'function') {
         callback(err, null, null);
+      } else {
+        reject(err);
       }
-      reject(err);
     }
 
     self._buildReqOpts(method, path, params, false, function (err, reqOpts) {
@@ -116,9 +117,14 @@ Twitter.prototype.request = function (method, path, params, callback) {
 
           if (callback && typeof callback === 'function') {
             callback(err, parsedBody, resp);
+          } else {
+            if (err) {
+              reject(err)
+            } else {
+              resolve({ data: parsedBody, resp: resp });
+            }
           }
 
-          resolve({ data: parsedBody, resp: resp });
           return;
         })
       })

--- a/tests/rest.js
+++ b/tests/rest.js
@@ -600,13 +600,13 @@ describe('REST API', function () {
 
   describe('error handling', function () {
     describe('handling errors from the twitter api', function () {
+      var twit = new Twit({
+        consumer_key: 'a',
+        consumer_secret: 'b',
+        access_token: 'c',
+        access_token_secret: 'd'
+      })
       it('should callback with an Error object with all the info and a response object', function (done) {
-        var twit = new Twit({
-          consumer_key: 'a',
-          consumer_secret: 'b',
-          access_token: 'c',
-          access_token_secret: 'd'
-        })
         twit.get('account/verify_credentials', function (err, reply, res) {
           assert(err instanceof Error)
           assert(err.statusCode === 401)
@@ -619,6 +619,21 @@ describe('REST API', function () {
           assert.equal(res.statusCode, 401)
           done()
         })
+      })
+      it('should return a rejected promise with the Twitter API errors', function() {
+          twit.get('account/verify_credentials')
+            .then(result => {
+              throw Error("Twitter API exception was not caught in the promise API")
+            })
+            .catch(err => {
+              assert(err instanceof Error)
+              assert(err.statusCode === 401)
+              assert(err.code > 0)
+              assert(err.message.match(/token/))
+              assert(err.twitterReply)
+              assert(err.allErrors)
+              return;
+            })
       })
     })
     describe('handling other errors', function () {


### PR DESCRIPTION
The primary change in this review is to make the Promise API return a rejected Promise when a Twitter API error occurs. Right now Twitter API errors are returned as a fulfilled promise.

The second change is to make the Promise API only reject/fulfill a promise if a callback is not provided. This is because if someone provides a callback, they probably aren't going to handle the rejected Promise, which I think will result in an error in some cases. (I got an Unhandled rejected promise error in the tests).
