### PR TITLE
Ignore timeout_ms when streaming

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -195,7 +195,7 @@ Twitter.prototype._buildReqOpts = function (method, path, params, isStreaming, c
     encoding: null,
   }
 
-  if (typeof self.config.timeout_ms !== 'undefined') {
+  if (typeof self.config.timeout_ms !== 'undefined' && !isStreaming) {
     reqOpts.timeout = self.config.timeout_ms;
   }
 


### PR DESCRIPTION
As observerd in #302, I think Twit should ignore the timeout from the Twit config when connecting to a stream.
