### PR TITLE
Fix bug in UTF-8 handling with gunzip decoding

### DIFF
--- a/lib/streaming-api-connection.js
+++ b/lib/streaming-api-connection.js
@@ -83,13 +83,14 @@ StreamingAPIConnection.prototype._startPersistentConnection = function () {
       var compressedBody = '';
 
       self.response.on('data', function (chunk) {
-        compressedBody += chunk.toString('utf8');
+        compressedBody += chunk;
       })
 
       var gunzip = zlib.createGunzip();
+      gunzip.setEncoding('utf8');
       self.response.pipe(gunzip);
       gunzip.on('data', function (chunk) {
-        body += chunk.toString('utf8')
+        body += chunk
       })
 
       gunzip.on('end', function () {
@@ -124,6 +125,7 @@ StreamingAPIConnection.prototype._startPersistentConnection = function () {
       // We got an OK status code - the response should be valid.
       // Read the body from the response and return to the user.
       var gunzip = zlib.createGunzip();
+      gunzip.setEncoding('utf8');
       self.response.pipe(gunzip);
 
       //pass all response data to parser
@@ -131,7 +133,7 @@ StreamingAPIConnection.prototype._startPersistentConnection = function () {
         self._connectInterval = 0
         // stop stall timer, and start a new one
         self._resetStallAbortTimeout();
-        self.parser.parse(chunk.toString('utf8'));
+        self.parser.parse(chunk);
       });
 
       gunzip.on('close', self._onClose.bind(self))


### PR DESCRIPTION
As observed in https://github.com/nodejs/node/issues/8701#issuecomment-248720337

Decoding each chunk separately could split Unicode symbols in half. This is avoided with gunzip.setEncoding, which already handles this.
