### PR TITLE
Change streaming to use utf8 and gzip decoding from request

### DIFF
--- a/lib/streaming-api-connection.js
+++ b/lib/streaming-api-connection.js
@@ -5,7 +5,6 @@ var util = require('util');
 var helpers = require('./helpers')
 var Parser = require('./parser');
 var request = require('request');
-var zlib = require('zlib');
 
 var STATUS_CODES_TO_ABORT_ON = require('./settings').STATUS_CODES_TO_ABORT_ON
 

--- a/lib/streaming-api-connection.js
+++ b/lib/streaming-api-connection.js
@@ -66,6 +66,7 @@ StreamingAPIConnection.prototype._startPersistentConnection = function () {
   self._setupParser();
   self._resetStallAbortTimeout();
   self._setOauthTimestamp();
+  this.reqOpts.encoding = 'utf8'
   self.request = request.post(this.reqOpts);
   self.emit('connect', self.request);
   self.request.on('response', function (response) {
@@ -80,19 +81,12 @@ StreamingAPIConnection.prototype._startPersistentConnection = function () {
       // We got a status code telling us we should abort the connection.
       // Read the body from the response and return an error to the user.
       var body = '';
-      var compressedBody = '';
 
-      self.response.on('data', function (chunk) {
-        compressedBody += chunk.toString('utf8');
+      self.request.on('data', function (chunk) {
+        body += chunk;
       })
 
-      var gunzip = zlib.createGunzip();
-      self.response.pipe(gunzip);
-      gunzip.on('data', function (chunk) {
-        body += chunk.toString('utf8')
-      })
-
-      gunzip.on('end', function () {
+      self.request.on('end', function () {
         try {
           body = JSON.parse(body)
         } catch (jsonDecodeError) {
@@ -108,13 +102,10 @@ StreamingAPIConnection.prototype._startPersistentConnection = function () {
         self.stop()
         body = null;
       });
-      gunzip.on('error', function (err) {
-        // If Twitter sends us back an uncompressed HTTP response, gzip will error out.
-        // Handle this by emitting an error with the uncompressed response body.
-        var errMsg = 'Gzip error: ' + err.message;
-        var twitErr = helpers.makeTwitError(errMsg);
+      self.request.on('error', function (err) {
+        var twitErr = helpers.makeTwitError(err.message);
         twitErr.statusCode = self.response.statusCode;
-        helpers.attachBodyInfoToError(twitErr, compressedBody);
+        helpers.attachBodyInfoToError(twitErr, body);
         self.emit('parser-error', twitErr);
       });
     } else if (self.response.statusCode === 420) {
@@ -123,21 +114,14 @@ StreamingAPIConnection.prototype._startPersistentConnection = function () {
     } else {
       // We got an OK status code - the response should be valid.
       // Read the body from the response and return to the user.
-      var gunzip = zlib.createGunzip();
-      self.response.pipe(gunzip);
-
       //pass all response data to parser
-      gunzip.on('data', function (chunk) {
+      self.request.on('data', function(data) {
         self._connectInterval = 0
-        // stop stall timer, and start a new one
         self._resetStallAbortTimeout();
-        self.parser.parse(chunk.toString('utf8'));
-      });
-
-      gunzip.on('close', self._onClose.bind(self))
-      gunzip.on('error', function (err) {
-        self.emit('error', err);
+        self.parser.parse(data);
       })
+
+      self.response.on('close', self._onClose.bind(self))
       self.response.on('error', function (err) {
         // expose response errors on twit instance
         self.emit('error', err);


### PR DESCRIPTION
This is an attempt to solve the zlib issue #300. Actually, to work around it:

Twit seems to be doing what `request` already is able to do: both decoding utf-8 and decompressing gzip. This PR lets `request` handle both.

It's working here and I don't get zlib errors anymore.

Not sure if the error handling is OK, feel free to edit it
