### PR TITLE
added shield to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 #twit
 
+[![API Testing](https://img.shields.io/badge/test%20this%20API%20on-RapidAPI.com-blue.svg)](https://rapidapi.com/package/Twitter/functions?utm_source=GithubTwitter&utm_medium=button)
+
 Twitter API Client for node
 
 Supports both the **REST** and **Streaming** API.


### PR DESCRIPTION
I've added a link in your README to Twitter's functions page in RapidAPI. I've done this for a few Twitter SDKs to help those who are reading the READMEs, understand and test the API before use.