### PR TITLE
Added support for the DELETE method.

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -65,9 +65,13 @@ Twitter.prototype.post = function (path, params, callback) {
   return this.request('POST', path, params, callback)
 }
 
+Twitter.prototype.delete = function (path, params, callback) {
+  return this.request('DELETE', path, params, callback)
+}
+
 Twitter.prototype.request = function (method, path, params, callback) {
   var self = this;
-  assert(method == 'GET' || method == 'POST');
+  assert(method == 'GET' || method == 'POST' || method == 'DELETE');
   // if no `params` is specified but a callback is, use default params
   if (typeof params === 'function') {
     callback = params


### PR DESCRIPTION
I needed to add this locally while testing the new webhook APIs, see https://dev.twitter.com/webhooks/reference.