### PR TITLE
New DM POST body support, DELETE HTTP method support, zlib flush

### DIFF
--- a/lib/streaming-api-connection.js
+++ b/lib/streaming-api-connection.js
@@ -7,6 +7,11 @@ var Parser = require('./parser');
 var request = require('request');
 var zlib = require('zlib');
 
+var ZLIB_OPT = {
+  flush: zlib.Z_SYNC_FLUSH,
+  finishFlush: zlib.Z_SYNC_FLUSH
+};
+
 var STATUS_CODES_TO_ABORT_ON = require('./settings').STATUS_CODES_TO_ABORT_ON
 
 var StreamingAPIConnection = function (reqOpts, twitOptions) {
@@ -86,7 +91,7 @@ StreamingAPIConnection.prototype._startPersistentConnection = function () {
         compressedBody += chunk.toString('utf8');
       })
 
-      var gunzip = zlib.createGunzip();
+      var gunzip = zlib.createGunzip(ZLIB_OPT);
       self.response.pipe(gunzip);
       gunzip.on('data', function (chunk) {
         body += chunk.toString('utf8')
@@ -123,7 +128,7 @@ StreamingAPIConnection.prototype._startPersistentConnection = function () {
     } else {
       // We got an OK status code - the response should be valid.
       // Read the body from the response and return to the user.
-      var gunzip = zlib.createGunzip();
+      var gunzip = zlib.createGunzip(ZLIB_OPT);
       self.response.pipe(gunzip);
 
       //pass all response data to parser

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -30,8 +30,11 @@ var FORMDATA_PATHS = [
 ];
 
 var JSONPAYLOAD_PATHS = [
-  'media/metadata/create'
-]
+  'media/metadata/create',
+  'direct_messages/events/new',
+  'direct_messages/welcome_messages/new',
+  'direct_messages/welcome_messages/rules/new'
+];
 
 //
 //  Twitter
@@ -65,9 +68,13 @@ Twitter.prototype.post = function (path, params, callback) {
   return this.request('POST', path, params, callback)
 }
 
+Twitter.prototype.delete = function(path, params, callback) {
+  return this.request('DELETE', path, params, callback);
+}
+
 Twitter.prototype.request = function (method, path, params, callback) {
   var self = this;
-  assert(method == 'GET' || method == 'POST');
+  assert(method == 'GET' || method == 'POST' || method == 'DELETE');
   // if no `params` is specified but a callback is, use default params
   if (typeof params === 'function') {
     callback = params


### PR DESCRIPTION

* Adds zLib flush solution from Issue #340*
* Whitelists new DM methods for POST body
* Adds DELETE as accepted HTTP method (`twit.delete`)

*Apologies for duplication, needed in my upstream also.