### PR TITLE
twitter api: check for END OF TEXT

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -305,27 +305,30 @@ Twitter.prototype._doRestApiRequest = function (reqOpts, twitOptions, method, ca
   var req = request_method(reqOpts);
 
   var body = '';
+  var err = null;
   var response = null;
 
   var onRequestComplete = function () {
     if (body !== '') {
-      try {
-        body = JSON.parse(body)
-      } catch (jsonDecodeError) {
-        // there was no transport-level error, but a JSON object could not be decoded from the request body
-        // surface this to the caller
-        var err = helpers.makeTwitError('JSON decode error: Twitter HTTP response body was not valid JSON')
-        err.statusCode = response ? response.statusCode: null;
-        err.allErrors.concat({error: jsonDecodeError.toString()})
-        callback(err, body, response);
-        return
+      if (body.indexOf('\u0003') < 0 && body.indexOf('\u0000') < 0) {
+        try {
+          body = JSON.parse(body)
+        } catch (jsonDecodeError) {
+          // there was no transport-level error, but a JSON object could not be decoded from the request body
+          // surface this to the caller
+          err = helpers.makeTwitError('JSON decode error: Twitter HTTP response body was not valid JSON')
+          err.statusCode = response ? response.statusCode: null;
+          err.allErrors.concat({error: jsonDecodeError.toString()})
+          callback(err, body, response);
+          return
+        }
       }
     }
 
     if (typeof body === 'object' && (body.error || body.errors)) {
       // we got a Twitter API-level error response
       // place the errors in the HTTP response body into the Error object and pass control to caller
-      var err = helpers.makeTwitError('Twitter API Error')
+      err = helpers.makeTwitError('Twitter API Error')
       err.statusCode = response ? response.statusCode: null;
       helpers.attachBodyInfoToError(err, body);
       callback(err, body, response);


### PR DESCRIPTION
Twitter API seems to have updated to allow for better functionality
related to DMs but may have changed something else under the hood. We are
getting a return payload with END OF TEXT code:

`'\u0003\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000'`

This PR checks for existence of this and continues with code instead of
throwing because of a `JSON.parse` failure.

Refs ttezel/twit#361