### PR TITLE
Add support for strictSSL request option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ var T = new Twit({
   access_token:         '...',
   access_token_secret:  '...',
   timeout_ms:           60*1000,  // optional HTTP request timeout to apply to all requests.
+  strictSSL:            true,     // optional - requires SSL certificates to be valid.
 })
 
 //

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -206,6 +206,10 @@ Twitter.prototype._buildReqOpts = function (method, path, params, isStreaming, c
     reqOpts.timeout = self.config.timeout_ms;
   }
 
+  if (typeof self.config.strictSSL !== 'undefined') {
+    reqOpts.strictSSL = self.config.strictSSL;
+  }
+
   try {
     // finalize the `path` value by building it using user-supplied params
     path = helpers.moveParamsIntoPath(finalParams, path)
@@ -475,6 +479,10 @@ Twitter.prototype._validateConfigOrThrow = function (config) {
 
   if (typeof config.timeout_ms !== 'undefined' && isNaN(Number(config.timeout_ms))) {
     throw new TypeError('Twit config `timeout_ms` must be a Number. Got: ' + config.timeout_ms + '.');
+  }
+
+  if (typeof config.strictSSL !== 'undefined' && typeof config.strictSSL !== 'boolean') {
+    throw new TypeError('Twit config `strictSSL` must be a Boolean. Got: ' + config.strictSSL + '.');
   }
 
   if (config.app_only_auth) {

--- a/tests/twit.js
+++ b/tests/twit.js
@@ -63,6 +63,20 @@ describe('twit', function () {
 
       done()
     })
+
+    it('throws when config provides invalid strictSSL option', function (done) {
+      assert.throws(function () {
+        var twit = new Twit({
+            consumer_key: 'a'
+          , consumer_secret: 'a'
+          , access_token: 'a'
+          , access_token_secret: 'a'
+          , strictSSL: 'a'
+        })
+      }, Error)
+
+      done()
+    })
   })
 
   describe('setAuth()', function () {


### PR DESCRIPTION
Allow passing `strictSSL` option to `request` via new config value. This will help with #7 as setting to `false` will allow us to establish connections when behind a proxy in certain scenarios.