### PR TITLE
removing app_only_auth prop

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -261,35 +261,23 @@ Twitter.prototype._buildReqOpts = function (method, path, params, isStreaming, c
     reqOpts.url += '?' + qs
   }
 
-  if (!self.config.app_only_auth) {
-    // with user auth, we can just pass an oauth object to requests
-    // to have the request signed
-    var oauth_ts = Date.now() + self._twitter_time_minus_local_time_ms;
+  // with user auth, we can just pass an oauth object to requests
+  // to have the request signed
+  var oauth_ts = Date.now() + self._twitter_time_minus_local_time_ms;
 
-    reqOpts.oauth = {
-      consumer_key: self.config.consumer_key,
-      consumer_secret: self.config.consumer_secret,
-      token: self.config.access_token,
-      token_secret: self.config.access_token_secret,
-      timestamp: Math.floor(oauth_ts/1000).toString(),
-    }
-
-    callback(null, reqOpts);
-    return;
-  } else {
-    // we're using app-only auth, so we need to ensure we have a bearer token
-    // Once we have a bearer token, add the Authorization header and return the fully qualified `reqOpts`.
-    self._getBearerToken(function (err, bearerToken) {
-      if (err) {
-        callback(err, null)
-        return
-      }
-
-      reqOpts.headers['Authorization'] = 'Bearer ' + bearerToken;
-      callback(null, reqOpts)
-      return
-    })
+  reqOpts.oauth = {
+    consumer_key: self.config.consumer_key,
+    consumer_secret: self.config.consumer_secret,
+    timestamp: Math.floor(oauth_ts/1000).toString()
   }
+
+  if (self.config.access_token) {
+    reqOpts.oauth.token = self.config.access_token
+    reqOpts.oauth.token_secret = self.config.access_token_secret
+  }
+
+  callback(null, reqOpts);
+  return;
 }
 
 /**
@@ -477,12 +465,12 @@ Twitter.prototype._validateConfigOrThrow = function (config) {
     throw new TypeError('Twit config `timeout_ms` must be a Number. Got: ' + config.timeout_ms + '.');
   }
 
-  if (config.app_only_auth) {
-    var auth_type = 'app-only auth'
-    var required_keys = required_for_app_auth
-  } else {
+  if (config.access_token) {
     var auth_type = 'user auth'
     var required_keys = required_for_user_auth
+  } else {
+    var auth_type = 'app-only auth'
+    var required_keys = required_for_app_auth
   }
 
   required_keys.forEach(function (req_key) {

--- a/tests/rest_app_only_auth.js
+++ b/tests/rest_app_only_auth.js
@@ -51,5 +51,30 @@ describe('REST API using app-only auth', function () {
       done()
     })
   })
-})
 
+  it('GET `users/show` { screen_name: twitter } multiple times', function (done) {
+    var index = 0
+    var limit = 50
+    var params = { screen_name: 'twitter' }
+
+    var getData = function () {
+      twit.get('users/show', params, function (err, data, response) {
+        if (data) {
+          assert.equal(783214, data.id)
+        } else {
+          throw new Error(err)
+        }
+
+        index++
+
+        if (index >= limit) {
+          done()
+        }
+      })
+    }
+
+    for (var i = 0; i <= limit; i++) {
+      getData()
+    }
+  })
+})


### PR DESCRIPTION
Hi, thanks for all your hard working on keeping this lib 🙂

I noticed some twitter api errors while doing several requests to specific endpoints (on the test here it was to `users/show`). After some debugging I removed `app_only_auth` from the requests and things are working and the test is passing. Couldn't say why only happens after 30/40 calls.