### PR TITLE
Fixed problem when making multiple calls to get bearer token

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -97,7 +97,7 @@ exports.getBearerToken = function (consumer_key, consumer_secret, cb) {
   // get a bearer token using our app's credentials
   var b64Credentials = new Buffer(consumer_key + ':' + consumer_secret).toString('base64');
   request.post({
-    url: endpoints.API_HOST + '/oauth2/token',
+    url: endpoints.API_HOST + 'oauth2/token',
     headers: {
       'Authorization': 'Basic ' + b64Credentials,
       'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8'
@@ -110,7 +110,7 @@ exports.getBearerToken = function (consumer_key, consumer_secret, cb) {
       exports.attachBodyInfoToError(error, body);
       return cb(error, body, res);
     }
-    
+
     if ( !body ) {
       var error = exports.makeTwitError('Not valid reply from Twitter upon obtaining bearer token');
       exports.attachBodyInfoToError(error, body);

--- a/tests/rest_app_only_auth.js
+++ b/tests/rest_app_only_auth.js
@@ -51,5 +51,29 @@ describe('REST API using app-only auth', function () {
       done()
     })
   })
-})
 
+  it('GET `users/show` { screen_name: twitter } multiple times', function (done) {
+    var index = 0
+    var limit = 50
+    var params = { screen_name: 'twitter' }
+
+    var getData = function () {
+      twit.get('users/show', params, function (err, data) {
+        if (data) {
+          assert.equal(783214, data.id)
+        } else {
+          throw new Error(err)
+        }
+        index++
+
+        if (index >= limit) {
+          done()
+        }
+      })
+    }
+
+    for (var i = 0; i <= limit; i++) {
+      getData()
+    }
+  })
+})


### PR DESCRIPTION
Before the bearer token is cached (for example you make 10 calls at the same time), for some reason you sometimes get random 404s
from the `POST /oauth2/token` call. I noticed its actually making a POST to
`//oauth2/token`, removing the extra forward slash seems to
fix the issue.

Reproduce by running `mocha tests/rest_app_only_auth.js -g 'multiple
times’` (adding back the extra forward slash in lib/helpers.js

Thanks to https://github.com/rssilva for the test case which I [stole](https://github.com/rssilva/twit/blob/464e53c4068cc7b0c25640f2f2669b206c06a605/tests/rest_app_only_auth.js) to reproduce the issue. 