### PR TITLE
Streaming: Use POST request body for sending params

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -254,7 +254,9 @@ Twitter.prototype._buildReqOpts = function (method, path, params, isStreaming, c
     }
   }
 
-  if (Object.keys(finalParams).length) {
+  if (isStreaming) {
+    reqOpts.form = finalParams
+  } else if (Object.keys(finalParams).length) {
     // not all of the user's parameters were used to build the request path
     // add them as a query string
     var qs = helpers.makeQueryString(finalParams)


### PR DESCRIPTION
Problem: Currently this library uses the url query string to send
parameters even in POST requests. Having a massive amount of `follow`
and `track` values in params when using the Streaming API will cause
Twitter to respond with `431 Request Header Fields Too Large`.

Solution: Send parameters in the request body with
`x-www-form-urlencoded` as content type.