### PR TITLE
Fix string enums used for media_category

### DIFF
--- a/lib/file_uploader.js
+++ b/lib/file_uploader.js
@@ -127,12 +127,12 @@ FileUploader.prototype._initMedia = function (cb) {
   var mediaType = mime.lookup(self._file_path);
   var mediaFileSizeBytes = fs.statSync(self._file_path).size;
   var shared = self._isSharedMedia;
-  var media_category = 'dm_image';
+  var media_category = 'tweet_image';
 
   if (mediaType.toLowerCase().indexOf('gif') > -1) {
-    media_category = 'dm_gif';
+    media_category = 'tweet_gif';
   } else if (mediaType.toLowerCase().indexOf('video') > -1) {
-    media_category = 'dm_video';
+    media_category = 'tweet_video';
   }
 
   // Check the file size - it should not go over 15MB for video.


### PR DESCRIPTION
This is intended to address #439 and #441

------

Twitter has started rejecting chunk media uploads with `media_category: 'dm_image'` with:  

```
{ code: 324, message: 'Unsupported raw media category' }
```
This corrects the enumerator strings to tweet_image, tweet_gif, and tweet_video respectively. Based on [andyroper's reply](https://twittercommunity.com/t/media-category-values/64781/7) in this [Twitter Community thread](https://twittercommunity.com/t/media-category-values/64781/4).