### PR TITLE
Update file_uploader.js

### DIFF
--- a/lib/file_uploader.js
+++ b/lib/file_uploader.js
@@ -44,7 +44,7 @@ FileUploader.prototype.upload = function (cb) {
     } else {
       var mediaTmpId = bodyObj.media_id_string;
       var chunkNumber = 0;
-      var mediaFile = fs.createReadStream(self._file_path, { highWatermark: MAX_FILE_CHUNK_BYTES });
+      var mediaFile = fs.createReadStream(self._file_path, { highWaterMark: MAX_FILE_CHUNK_BYTES });
 
       mediaFile.on('data', function (chunk) {
         // Pause our file stream from emitting `data` events until the upload of this chunk completes.


### PR DESCRIPTION
The "HighWaterMark" had a typo and the MAX_FILE_CHUNK_BYTES wasn't being respected, leading to significantly more chunks and slower uploads for larger files.