### PR TITLE
FileUploader: use correct highWaterMark field

### DIFF
--- a/lib/file_uploader.js
+++ b/lib/file_uploader.js
@@ -44,7 +44,7 @@ FileUploader.prototype.upload = function (cb) {
     } else {
       var mediaTmpId = bodyObj.media_id_string;
       var chunkNumber = 0;
-      var mediaFile = fs.createReadStream(self._file_path, { highWatermark: MAX_FILE_CHUNK_BYTES });
+      var mediaFile = fs.createReadStream(self._file_path, { highWaterMark: MAX_FILE_CHUNK_BYTES });
 
       mediaFile.on('data', function (chunk) {
         // Pause our file stream from emitting `data` events until the upload of this chunk completes.


### PR DESCRIPTION
According to https://nodejs.org/docs/latest-v8.x/api/fs.html#fs_fs_createreadstream_path_options, the field name should be `highWaterMark`, uppercase `M`.

The chunks were actually defaulting to `64*1024`, which causes longer upload times due to having a lot more requests, which means a higher total RTT.