### PR TITLE
Add headers to REST error object

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -343,6 +343,7 @@ Twitter.prototype._doRestApiRequest = function (reqOpts, twitOptions, method, ca
       // place the errors in the HTTP response body into the Error object and pass control to caller
       var err = helpers.makeTwitError('Twitter API Error')
       err.statusCode = response ? response.statusCode: null;
+      err.headers = response ? response.headers : null;
       helpers.attachBodyInfoToError(err, body);
       callback(err, body, response);
       return

--- a/tests/rest.js
+++ b/tests/rest.js
@@ -638,6 +638,7 @@ describe('REST API', function () {
           assert(err.statusCode === 401)
           assert(err.code > 0)
           assert(err.message.match(/token/))
+          assert(typeof err.headers === 'object')
           assert(err.twitterReply)
           assert(err.allErrors)
           assert(res)
@@ -654,6 +655,7 @@ describe('REST API', function () {
             .catch(err => {
               assert(err instanceof Error)
               assert(err.statusCode === 401)
+              assert(typeof err.headers === 'object')
               assert(err.code > 0)
               assert(err.message.match(/token/))
               assert(err.twitterReply)


### PR DESCRIPTION
Problem: Twitter provides rate limit information via custom HTTP headers on each request, but, as of commit 8fcea75f2c01db9f0f9c053030ceb0b948ec2ca1, the promise interface no longer exposes the full response from Twitter, so this info is no longer available from 4xx or 5xx responses.

Solution: Attach the headers to the error in the same way that the response body and status code are attached. Since this is relevant metadata for managing Twitter requests, it makes sense to me to include this here, and it shouldn't be too much noise. I also considered attaching the full response to the error object, but that felt excessive. I'm open to discussion either way, though. Thanks for all your work on this!