### PR TITLE
Fix banner update URL (update_profile_background_image is deprecated)

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -26,7 +26,7 @@ var required_for_user_auth = required_for_app_auth.concat([
 var FORMDATA_PATHS = [
   'media/upload',
   'account/update_profile_image',
-  'account/update_profile_background_image',
+  'account/update_profile_banner',
 ];
 
 var JSONPAYLOAD_PATHS = [


### PR DESCRIPTION
Fix banner update url
https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/post-account-update_profile_banner.html