### PR TITLE
Use correct-content type when GET-ing a media/ path

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -251,7 +251,7 @@ Twitter.prototype._buildReqOpts = function (method, path, params, isStreaming, c
       reqOpts.url = endpoints.REST_ROOT + path + '.json';
     }
 
-    if (FORMDATA_PATHS.indexOf(path) !== -1) {
+    if (FORMDATA_PATHS.indexOf(path) !== -1 && method === 'POST') {
       reqOpts.headers['Content-type'] = 'multipart/form-data';
       reqOpts.form = finalParams;
        // set finalParams to empty object so we don't append a query string


### PR DESCRIPTION
Fixes https://github.com/ttezel/twit/issues/463 and https://github.com/ttezel/twit/issues/259