### PR TITLE
Add support for subtitles create and delete

### DIFF
--- a/lib/file_uploader.js
+++ b/lib/file_uploader.js
@@ -133,6 +133,8 @@ FileUploader.prototype._initMedia = function (cb) {
     media_category = 'tweet_gif';
   } else if (mediaType.toLowerCase().indexOf('video') > -1) {
     media_category = 'tweet_video';
+  } else if (mediaType.toLowerCase().indexOf('subrip') > -1) {
+    media_category = 'SUBTITLES'
   }
 
   // Check the file size - it should not go over 15MB for video.

--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -31,6 +31,8 @@ var FORMDATA_PATHS = [
 
 var JSONPAYLOAD_PATHS = [
   'media/metadata/create',
+  'media/subtitles/create',
+  'media/subtitles/delete',
   'direct_messages/events/new',
   'direct_messages/welcome_messages/new',
   'direct_messages/welcome_messages/rules/new',


### PR DESCRIPTION
As of late May, users can create and delete subtitles via the Twitter API. 

https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-subtitles-create
https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-subtitles-delete

These endpoints require passing a JSON payload. To allow twit to support these endpoints, the subtitle endpoints need to be added to the JSONPAYLOAD_PATHS variable in twitter.js. In addition, to upload subtitles via the chunked media upload, the media_category must be set to "SUBTITLES".