### PR TITLE
Bugfix: account/update_profile_banner

### DIFF
--- a/lib/twitter.js
+++ b/lib/twitter.js
@@ -26,7 +26,7 @@ var required_for_user_auth = required_for_app_auth.concat([
 var FORMDATA_PATHS = [
   'media/upload',
   'account/update_profile_image',
-  'account/update_profile_background_image',
+  'account/update_profile_banner',
 ];
 
 var JSONPAYLOAD_PATHS = [


### PR DESCRIPTION
Updates old path `account/update_profile_background_image` to new path `account/update_profile_banner`

**Test:** 
```
 twit.post("account/update_profile_banner", {
     banner: "base64Image"
 });
```
**Result:**
Banner image of authenticated account is updated.