### PR TITLE
added user defined media_category support

### DIFF
--- a/lib/file_uploader.js
+++ b/lib/file_uploader.js
@@ -22,6 +22,7 @@ var FileUploader = function (params, twit) {
   assert(params.file_path, 'Must specify `file_path` to upload a file. Got: ' + params.file_path + '.')
   var self = this;
   self._file_path = params.file_path;
+  self._media_category = params.media_category
   self._twit = twit;
   self._isUploading = false;
   self._isFileStreamEnded = false;
@@ -134,7 +135,7 @@ FileUploader.prototype._initMedia = function (cb) {
   } else if (mediaType.toLowerCase().indexOf('video') > -1) {
     media_category = 'tweet_video';
   }
-
+  media_category = self._media_category || media_category;
   // Check the file size - it should not go over 15MB for video.
   // See https://dev.twitter.com/rest/reference/post/media/upload-chunked
   if (mediaFileSizeBytes < MAX_FILE_SIZE_BYTES) {


### PR DESCRIPTION
for direct message we need to define the media category: dm_image, dm_gif, dm_video

https://developer.twitter.com/en/docs/direct-messages/message-attachments/guides/attaching-media